### PR TITLE
Setting 'severity' per task result

### DIFF
--- a/src/main/java/com/philemonworks/selfdiagnose/DiagnosticTaskResult.java
+++ b/src/main/java/com/philemonworks/selfdiagnose/DiagnosticTaskResult.java
@@ -12,7 +12,7 @@
  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  See the License for the specific language governing permissions and
  limitations under the License.
- 
+
  */
 package com.philemonworks.selfdiagnose;
 
@@ -32,7 +32,7 @@ import org.apache.log4j.Logger;
  * <li>Error means: execution task failed (because of Exception)</li>
  * <li>Unknown means: result is not set and therefore not reported</li>
  * </ul>
- * 
+ *
  * @author emicklei
  */
 public class DiagnosticTaskResult {
@@ -54,7 +54,7 @@ public class DiagnosticTaskResult {
     private final String requestor;
 
     @Expose
-    private final String severity;
+    private String severity;
 
     @Expose
     private String status = STATUS_UNKNOWN;
@@ -74,7 +74,7 @@ public class DiagnosticTaskResult {
 
     /**
      * Constructor requires a DiagnosticTask to store the result of its run.
-     * 
+     *
      * @param task
      *            DiagnosticTask
      */
@@ -93,7 +93,7 @@ public class DiagnosticTaskResult {
 
     /**
      * Indicates the outcome of the task
-     * 
+     *
      * @return STATUS_PASSED || STATUS_FAILED || STATUS_ERROR
      */
     public String getStatus() {
@@ -134,7 +134,7 @@ public class DiagnosticTaskResult {
 
     /**
      * Set the message explaining why the run has failed.
-     * 
+     *
      * @param aMessage
      */
     public void setErrorMessage(String aMessage) {
@@ -177,7 +177,7 @@ public class DiagnosticTaskResult {
 
     /**
      * Return the DiagnosticTask for which the result hold the results.
-     * 
+     *
      * @return DiagnosticTask
      */
     public DiagnosticTask getTask() {
@@ -186,7 +186,7 @@ public class DiagnosticTaskResult {
 
     /**
      * Add a message to the list of reporting messages
-     * 
+     *
      * @param passedMessage
      *            String
      */
@@ -243,4 +243,7 @@ public class DiagnosticTaskResult {
         return severity;
     }
 
+    public void setSeverity(Severity severity) {
+        this.severity = severity.name();
+    }
 }

--- a/src/main/java/com/philemonworks/selfdiagnose/output/XMLReporter.java
+++ b/src/main/java/com/philemonworks/selfdiagnose/output/XMLReporter.java
@@ -12,7 +12,7 @@
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
-   
+
 */
 package com.philemonworks.selfdiagnose.output;
 
@@ -30,7 +30,7 @@ import com.philemonworks.selfdiagnose.XMLUtils;
 /**
  * XMLReporter creates an XML document (String) with all the results of running SelfDiagnose.
  * The document conforms to the selfdiagnose.xsd.
- * 
+ *
  * @author ernestmicklei
  *
  */
@@ -70,6 +70,8 @@ public class XMLReporter implements DiagnoseRunReporter {
         xml.append(result.getTask().getRequestor());
         xml.append("\"\n\t\t\tduration=\"");
         xml.append((String.valueOf(result.getExecutionTime())));
+        xml.append("\"\n\t\t\tseverity=\"");
+        xml.append((String.valueOf(result.getSeverity())));
         xml.append("\" />\n");
     }
 


### PR DESCRIPTION
With this change it becomes possible to set a severity per task result. 

As a bonus the severity is also added to the XML report.
